### PR TITLE
BLD: Skip building of musllinux wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ plugins = ["Cython.Coverage"]
 
 
 [tool.cibuildwheel]
-skip = "pp3*"
+skip = ["pp3*", "*-musllinux*"]
 test-command = [
     "cd ~",
     """python -c '\


### PR DESCRIPTION
too buggy. No point in trying at this point in time.