### PR TITLE
REL: Update pypi uploading workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,19 @@ jobs:
   upload_pypi:
     needs: [ build_wheels_and_sdist ]
     runs-on: ubuntu-20.04
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyhtnorm
+    permissions:
+      id-token: write
     steps:
-      - name: Pull built wheels and sdist
-        uses: actions/download-artifact@v2
+      - name: Pull built wheel and sdist
+        uses: actions/download-artifact@v3
         with:
           name: wheels_and_sdist
           path: wheelhouse
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@v1.8.5
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
           packages_dir: wheelhouse


### PR DESCRIPTION
use trusted publisher workflow cause the old one doesn't work anymore
